### PR TITLE
Potential fix for code scanning alert no. 5: Server-side request forgery

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -2,6 +2,21 @@
 import { getPublicUrl } from "@/utils/image";
 import { ImageResponse } from "next/og";
 
+// Allow-list for external thumbnail domains
+const ALLOWED_THUMBNAIL_HOSTS = [
+  "cdn.jsdelivr.net", // Example CDN host, add any trusted host here
+  "your-cdn-domain.com",
+];
+
+function isAllowedExternalUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return ALLOWED_THUMBNAIL_HOSTS.includes(parsed.hostname);
+  } catch (e) {
+    return false;
+  }
+}
+
 export const runtime = "edge";
 const pretendardFont = fetch(
   "https://cdn.jsdelivr.net/npm/pretendard@1.3.9/dist/public/static/Pretendard-ExtraBold.otf"
@@ -19,6 +34,14 @@ export async function GET(request: Request) {
     );
     if (!thumbnail) {
       return new Response("Thumbnail is required", { status: 400 });
+    }
+
+    // SSRF mitigation: Only allow thumbnail URLs from approved hosts
+    if (
+      (thumbnail.startsWith("http://") || thumbnail.startsWith("https://")) &&
+      !isAllowedExternalUrl(thumbnail)
+    ) {
+      return new Response("Untrusted thumbnail URL", { status: 400 });
     }
 
     const imageRes = await fetch(thumbnail);

--- a/utils/image.ts
+++ b/utils/image.ts
@@ -12,6 +12,19 @@ export function getPublicUrl(fileName?: string): string {
 
   // 파일 이름이 절대경로 시작하면 그대로 반환
   if (fileName.startsWith("http:") || fileName.startsWith("https:")) {
+    // Optionally reject unapproved external URLs at this level too
+    try {
+      const parsed = new URL(fileName);
+      const allowed = [
+        "cdn.jsdelivr.net", // Add trusted hosts here
+        "your-cdn-domain.com",
+      ];
+      if (!allowed.includes(parsed.hostname)) {
+        return ""; // Block/return blank for untrusted host
+      }
+    } catch {
+      return "";
+    }
     return fileName;
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/zzoyu/weaving/security/code-scanning/5](https://github.com/zzoyu/weaving/security/code-scanning/5)

To fix this SSRF vulnerability, you must restrict which URLs the server will fetch as thumbnails. The best practice is to enforce a allow-list of domains to which outbound requests can be made, or to ensure that only certain forms of file paths or known URLs are permitted. Since `getPublicUrl` allows absolute external URLs, you should change it so that only URLs pointing to trusted domains (such as your CDN or blob store) are allowed, or even better, restrict it such that only relative file paths (which are resolved against a known base URL) are permitted and block any direct "http:"/ "https:" URLs. You can implement this at two locations:
- In the GET handler in `route.tsx`—add a domain allow-list validation for "http:"/ "https:" URLs before making any outbound request.
- Alternatively (and more future-proof), alter `getPublicUrl` to reject user input that starts with "http:" or "https:" unless it's a trusted domain (by parsing the hostname and checking against a known set).

The fix requires modifying both files:
- Add a constant with allowed domains (such as the CDN domain).
- Create a helper function to check URLs against an allow-list.
- Use this helper in `route.tsx` to block fetch requests to untrusted domains.
- Optionally, strengthen `getPublicUrl` against risky input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
